### PR TITLE
公開鍵の編集エラーを修正

### DIFF
--- a/src/app/api/pubkeys/route.ts
+++ b/src/app/api/pubkeys/route.ts
@@ -24,7 +24,7 @@ export const GET = async (
 export const PUT = async (req: NextRequest): Promise<NextResponse> => {
   const userID = req.headers.get(HEADER_USERID);
   if (userID === null) {
-    console.error("GET /api/pubkey: userID not found in header");
+    console.error("PUT /api/pubkey: userID not found in header");
     return new NextResponse(null, { status: statusUnauthorized });
   }
 
@@ -36,7 +36,10 @@ export const PUT = async (req: NextRequest): Promise<NextResponse> => {
     );
   }
 
-  await ldap.replacePubkeys(userID, pubkeys);
+  // Deduplicate public keys
+  const dedupPubkeys = Array.from(new Set(pubkeys));
+
+  await ldap.replacePubkeys(userID, dedupPubkeys);
   return NextResponse.json({ success: true, pubkeys });
 };
 

--- a/src/app/pubkey/page.tsx
+++ b/src/app/pubkey/page.tsx
@@ -24,6 +24,7 @@ import {
 import { Schema, schema } from "./schema";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { usePubkeys, usePutPubkey } from "@/lib/hooks/pubkey";
+import { Add, Delete } from "@mui/icons-material";
 
 export default function Pubkey() {
   const [alertOpen, setAlertOpen] = useState(false);
@@ -85,14 +86,13 @@ export default function Pubkey() {
     setAlertOpen(false);
   };
 
-  const textFields = fields.map((_item, index, { length }) => (
+  const textFields = fields.map(({ id }, index) => (
     <PubkeyRow
-      key={index}
+      key={id}
       {...{
-        action: length - 1 === index ? "add" : "delete",
+        id,
         index,
         control,
-        append,
         remove,
       }}
     />
@@ -116,6 +116,15 @@ export default function Pubkey() {
         >
           {textFields}
 
+          <Button
+            type="button"
+            variant="contained"
+            color="secondary"
+            sx={{ display: "flex", paddingRight: "1.5em" }}
+            onClick={() => append({ value: "" })}
+          >
+            <Add /> Add
+          </Button>
           <Button
             type="submit"
             variant="contained"
@@ -145,52 +154,29 @@ export default function Pubkey() {
 }
 
 interface PubkeyRowProps {
-  action: "add" | "delete";
+  id: string;
   index: number;
   control: Control<Schema>;
-  append: UseFieldArrayAppend<Schema>;
   remove: UseFieldArrayRemove;
 }
 
-const PubkeyRow = ({
-  action,
-  control,
-  index,
-  append,
-  remove,
-}: PubkeyRowProps) => {
-  let button: ReactElement;
-  switch (action) {
-    case "add":
-      button = (
-        <Button
-          type="button"
-          variant="contained"
-          color="secondary"
-          onClick={() => append({ value: "" })}
-        >
-          Add
-        </Button>
-      );
-      break;
-    case "delete":
-      button = (
-        <Button
-          type="button"
-          variant="contained"
-          color="error"
-          onClick={() => remove(index)}
-        >
-          Delete
-        </Button>
-      );
-      break;
-  }
+const PubkeyRow = ({ id, control, index, remove }: PubkeyRowProps) => {
+  let button: ReactElement = (
+    <Button
+      type="button"
+      variant="contained"
+      color="error"
+      sx={{ display: "flex", gap: 0.3, paddingRight: "1.5em" }}
+      onClick={() => remove(index)}
+    >
+      <Delete /> DELETE
+    </Button>
+  );
 
   return (
     <Controller
       name={`pubkeys.${index}.value`}
-      key={index}
+      key={id}
       control={control}
       render={({ field, fieldState }) => (
         <Stack direction="row" spacing={2} width="100%">


### PR DESCRIPTION
## 問題

- `/pubkey` ページにて、公開鍵を登録・編集・削除しようとすると 500 エラーで失敗する場合があった
- 行 N の DELETE ボタンを押しても実際に削除されるのは一番下の行で、想定通りの更新内容にならなかった

## 原因

- slapd のエラー: `Attribute Or Value Exists` 
- 空文字列など、重複した値が登録されていたことが原因だった
  - 二点目の問題もあわさって重複が起こりやすかった

## やったこと

1. リクエスト送信時、重複した値を削除するようにした
2. DELETE ボタンが正しい位置の行を削除するよう修正した
3. UI を変え、すべての行に DELETE ボタンを設置し、 ADD ボタンは独立させた
4. ついでに ADD/DELETE にアイコンをつけて見やすくした

Before:

![image](https://github.com/user-attachments/assets/cdbe4b59-f3e7-443b-abe0-12e6ac5f2772)

After:

![image](https://github.com/user-attachments/assets/ab846abd-fe26-44a2-a51c-553607843b13)

(Closes #5 )